### PR TITLE
Updates for Mimosa 3.0

### DIFF
--- a/mimosa-config.coffee
+++ b/mimosa-config.coffee
@@ -4,6 +4,9 @@ exports.config =
     sourceDir: "src"
     compiledDir: "lib"
     javascriptDir: null
+  coffeescript:
+    options:
+      sourceMap:false
   jshint:
     rules:
       node: true

--- a/src/blesser.coffee
+++ b/src/blesser.coffee
@@ -17,7 +17,7 @@ writeFiles = (blessData, input, output) ->
     logger.success "#{numFiles} CSS files created for #{input}"
   else
     logger.success "No changes made."
- 
+
 blessFile = (input, output, options, next) ->
   unless fs.existsSync input
     return logger.warn "mimosa-bless: bless file [[ #{input} ]] does not exist"
@@ -91,7 +91,7 @@ blessAll = (mimosaConfig, options, next) ->
       finish input
 
 blessCommand = (retrieveConfig) ->
-  retrieveConfig false, (config) ->
+  retrieveConfig { buildFirst: false }, (config) ->
     config.isBuild = true
     blessAll config, {}, (->)
 

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -15,20 +15,6 @@ exports.defaults = ->
     files: []
     blessOnWatch: true
 
-exports.placeholder = ->
-  """
-  \t
-  #bless:
-  #  options:
-  #    cacheBuster: true,
-  #    cleanup: true,
-  #    compress: false,
-  #    force: false,
-  #    imports: true
-  #  files: []
-  #  blessOnWatch: true #turn this off if it goes slow for large code bases during watch mode
-  """
-
 exports.validate = (config, validators) ->
   errors = []
   {bless} = config

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -18,6 +18,5 @@ registerCommand = (program, retrieveConfig) ->
 module.exports =
   registration:    registration
   defaults:        config.defaults
-  placeholder:     config.placeholder
   validate:        config.validate
   registerCommand: registerCommand

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -8,7 +8,7 @@ registration = (mimosaConfig, register) ->
   register ['add', 'update', 'remove'], 'afterWrite', blesser.checkForBless
   register ['postBuild'], 'init', blesser.blessAll
 
-registerCommand = (program, retrieveConfig) ->
+registerCommand = (program, logger, retrieveConfig) ->
   program
     .command('bless')
     .description('invokes bless compiler using config settings')


### PR DESCRIPTION
dbashford/mimosa#439
1. Removed the `placeholder` function as it will no longer be used with Mimosa 3.0+.  Removing it does not break pre 3.0 as Mimosa is fine if it doesn't exist.
2. Updated the function signatures for registering commands.  Up to Mimosa 3.0 several varieties have been supported, but going forward many will be removed.  Again, this doesn't break pre-3.0 as the signatures being used going forward have been in place for awhile.
3. Updated mimosa-config to not output source maps for compiled coffeescript.  As it stood, source maps were being deployed to NPM.

Tests didn't seem to need updates as tests completed successfully.

Thanks!
